### PR TITLE
Ajuste do retorno da mensagem de exceção

### DIFF
--- a/src/Horse.Exception.Logger.pas
+++ b/src/Horse.Exception.Logger.pas
@@ -119,7 +119,7 @@ var
     LLog := LLog.Replace('${response_title}', THorseExceptionLogger.ValidateValue(AResponse.RawWebResponse.Title));
     LLog := LLog.Replace('${response_content_version}', THorseExceptionLogger.ValidateValue(AResponse.RawWebResponse.ContentVersion));
     {$ENDIF}
-    LLog := LLog.Replace('${exception}', THorseExceptionLogger.ValidateValue(LJSON.toString));
+    LLog := LLog.Replace('${exception}', THorseExceptionLogger.ValidateValue(LJSON.AsJSON));
   end;
 begin
   LBeforeDateTime := Now();


### PR DESCRIPTION
Retorno da mensagem de exceção estava retornando o nome do objeto e o log estava ficando conforme abaixo

127.0.0.1 [26/abril/2023 09:27:51:228] "GET /raise 1.1" 500 TJSONObject

o código foi ajustado para retornar a mensagem do objeto json da exceção

LLog := LLog.Replace('${exception}', THorseExceptionLogger.ValidateValue(LJSON.AsJSON));  

